### PR TITLE
Upgrade build tools and migrate to Kotlin compilerOptions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     alias(libs.plugins.android.app.module.conventions)
     alias(libs.plugins.android.koin.conventions)
@@ -23,8 +26,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -13,8 +14,8 @@ java {
     targetCompatibility = JavaVersion.VERSION_21
 }
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 
@@ -48,7 +49,7 @@ gradlePlugin {
 
 // Necessary for context receiver
 //tasks.withType<KotlinCompile>().configureEach {
-//    kotlinOptions {
-//        freeCompilerArgs = freeCompilerArgs + "-Xcontext-receivers"
+//    compilerOptions {
+//        freeCompilerArgs.add("-Xcontext-receivers")
 //    }
 //}

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -8,6 +8,10 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.gradle.kotlin.dsl.withType
+
 class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
@@ -25,23 +29,11 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 defaultConfig.versionName = "1.0"
                 defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
             }
-
-            app {
-                defaultConfig {
-                    minSdk = projectLibs.findVersion("app-minSdk").get().displayName.toInt()
-                    targetSdk = projectLibs.findVersion("app-targetSdk").get().displayName.toInt()
-                    compileSdk = projectLibs.findVersion("app-compileSdk").get().displayName.toInt()
-                }
-                compileOptions {
-                    sourceCompatibility = JavaVersion.VERSION_21
-                    targetCompatibility = JavaVersion.VERSION_21
-                }
-            }
         }
         // Necessary for context receiver
 //        target.tasks.withType<KotlinCompile>().configureEach {
-//            kotlinOptions {
-//                freeCompilerArgs = freeCompilerArgs + "-Xcontext-receivers"
+//            compilerOptions {
+//                freeCompilerArgs.add("-Xcontext-receivers")
 //            }
 //        }
     }

--- a/build-logic/convention/src/main/kotlin/extensions/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/extensions/KotlinAndroid.kt
@@ -19,15 +19,11 @@ internal fun Project.configureKotlinAndroid(
     commonExtension.apply {
         compileSdk = projectLibs.findVersion("app-compileSdk").get().displayName.toInt()
 
-        defaultConfig {
-            minSdk = projectLibs.findVersion("app-minSdk").get().displayName.toInt()
-        }
+        defaultConfig.minSdk = projectLibs.findVersion("app-minSdk").get().displayName.toInt()
 
-        compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_21
-            targetCompatibility = JavaVersion.VERSION_21
-            isCoreLibraryDesugaringEnabled = true
-        }
+        compileOptions.sourceCompatibility = JavaVersion.VERSION_21
+        compileOptions.targetCompatibility = JavaVersion.VERSION_21
+        compileOptions.isCoreLibraryDesugaringEnabled = true
     }
 
     configureKotlin<KotlinAndroidProjectExtension>()

--- a/common-kotlin/build.gradle.kts
+++ b/common-kotlin/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     alias(libs.plugins.android.koin.conventions)
 
@@ -26,9 +29,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
-    }
 
     buildTypes {
         release {
@@ -44,4 +44,10 @@ android {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.kotlinx.serialization.json)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_21)
+    }
 }

--- a/data-preference/impl/build.gradle.kts
+++ b/data-preference/impl/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -30,8 +33,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,13 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ app-minSdk = "24"
 
 #libs
 androidDesugarJdkLibs = "2.1.5"
-agp = "8.13.2"
+agp = "9.2.1"
 gradle = "8.13.2"
 kotlin = "2.2.21"
 coreKtx = "1.17.0"
@@ -32,7 +32,7 @@ googleTruth = "1.4.5"
 #plugin
 googleServices = "4.4.4"
 firebaseAppDistribution = "5.2.0"
-ksp = "2.2.0-2.0.2"
+ksp = "2.3.2"
 
 jvmTarget = "21"
 appcompat = "1.7.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Oct 12 18:08:13 EEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Update Gradle to 9.4.1, AGP to 9.2.1, and KSP to 2.3.2.
- Replace deprecated `kotlinOptions` with the modern `compilerOptions` DSL in all Gradle scripts.
- Add several Android Gradle Plugin flags to `gradle.properties` for build features and R8 configuration.
- Refactor convention plugins to simplify SDK and compilation settings.